### PR TITLE
feat: PostHog identify for form and newsletter conversions

### DIFF
--- a/app/[locale]/contact/contact.tsx
+++ b/app/[locale]/contact/contact.tsx
@@ -8,6 +8,7 @@ import LocationCard from "@repo/ui/components/location-card"
 import TitleSubtitle from "@repo/ui/components/title-subtitle"
 import { TcontactTarget } from "@repo/middleware/types"
 import { generateSchemaFromFields } from "@repo/ui/lib/zod-transformation"
+import { identifyPostHogFormSubmitter } from "../../lib/posthog-identify"
 
 export default function ContactChildPage({ idContact }: { idContact: TcontactTarget }) {
     const [ContactMessage, fnSetContactMessage] = useState("")
@@ -92,6 +93,17 @@ export default function ContactChildPage({ idContact }: { idContact: TcontactTar
                                         schema: generateSchemaFromFields(idContact.contact.contactForm || []),
                                     }}
                                     onSuccess={fnHandleContactSuccess}
+                                    onSuccessfulSubmit={(idPayload) => {
+                                        identifyPostHogFormSubmitter(
+                                            idPayload.formData,
+                                            {
+                                                formId: "contact",
+                                                formTitle: idPayload.formTitle,
+                                                formSource: "contact_form",
+                                                newsletterOptIn: idPayload.formData.newsletter === true,
+                                            },
+                                        )
+                                    }}
                                     className="shadow-none bg-transparent p-0 border-none"
                                     hideCardHeader={true}
                                 />
@@ -154,6 +166,17 @@ export default function ContactChildPage({ idContact }: { idContact: TcontactTar
                                         schema: generateSchemaFromFields(idContact.contact.bookingForm || []),
                                     }}
                                     onSuccess={fnHandleBookingSuccess}
+                                    onSuccessfulSubmit={(idPayload) => {
+                                        identifyPostHogFormSubmitter(
+                                            idPayload.formData,
+                                            {
+                                                formId: "booking",
+                                                formTitle: idPayload.formTitle,
+                                                formSource: "booking_form",
+                                                newsletterOptIn: idPayload.formData.newsletter === true,
+                                            },
+                                        )
+                                    }}
                                     className="shadow-none bg-transparent p-0 border-none"
                                     hideCardHeader={true}
                                 />

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -5,6 +5,7 @@ import { GeistSans } from 'geist/font/sans'
 import { fnGetCacheData } from '../utils/strapi/get-data'
 import ChatInit from "../components/chat-int"
 import ClientLayout from "..//components/client-layout"
+import NewsletterIdentifyListener from "../components/newsletter-identify-listener"
 import Footer from "@repo/ui/components/footer"
 import Navbar from "@repo/ui/components/navbar"
 import { ThemeProvider } from "@repo/ui/components/theme-provider"
@@ -111,6 +112,7 @@ export default async function RootLayout({
           </main>
           <Footer idFooter={footerData} />
         </ThemeProvider>
+        <NewsletterIdentifyListener />
         <ChatInit />
       </body>
     </html>

--- a/app/[locale]/solutions/[slug]/casestudy.tsx
+++ b/app/[locale]/solutions/[slug]/casestudy.tsx
@@ -271,7 +271,7 @@ export default function CaseStudyPage({
             </div>
           </div>
         </section>
-        {fnRenderFormBelowSection("containerFive")}
+        {fnRenderFormBelowSection("containerFive", { idPdfData: idcaseStudies })}
       </div >
     </>
   );

--- a/app/[locale]/solutions/[slug]/casestudy.tsx
+++ b/app/[locale]/solutions/[slug]/casestudy.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import posthog from "posthog-js";
 import Link from "next/link";
 import * as Icons from "lucide-react";
 import { ArrowLeft, LucideIcon } from "lucide-react";
@@ -53,9 +52,6 @@ export default function CaseStudyPage({
                 ).find((btn) => "formMode" in btn);
                 return LaButton
                   ? () => {
-                    posthog.capture("case_study_download_requested", {
-                      case_study_name: idcaseStudies.caseStudies[0]?.name,
-                    });
                     fnHandleFormButtonClick(
                       LaButton.formMode as TformMode,
                       "containerTwo",

--- a/app/components/newsletter-identify-listener.tsx
+++ b/app/components/newsletter-identify-listener.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import { useEffect } from "react"
+import { identifyPostHogFormSubmitter } from "../lib/posthog-identify"
+
+type TNewsletterSubscribedEvent = CustomEvent<{
+  email?: string
+  status?: "subscribed" | "already_subscribed" | "error"
+}>
+
+export default function NewsletterIdentifyListener() {
+  useEffect(() => {
+    const fnHandleNewsletterSubscribed = (iEvent: Event) => {
+      const LdEvent = iEvent as TNewsletterSubscribedEvent
+
+      if (
+        !LdEvent.detail?.email ||
+        !["subscribed", "already_subscribed"].includes(LdEvent.detail.status ?? "error")
+      ) {
+        return
+      }
+
+      identifyPostHogFormSubmitter(
+        { email: LdEvent.detail.email },
+        {
+          formId: "newsletter",
+          formSource: "footer_newsletter",
+          formTitle: "Footer newsletter",
+          newsletterOptIn: true,
+        },
+      )
+    }
+
+    window.addEventListener("newsletter_subscribed", fnHandleNewsletterSubscribed)
+
+    return () => {
+      window.removeEventListener("newsletter_subscribed", fnHandleNewsletterSubscribed)
+    }
+  }, [])
+
+  return null
+}

--- a/app/hooks/form-handler.tsx
+++ b/app/hooks/form-handler.tsx
@@ -68,6 +68,26 @@ export const useFormHandler = () => {
         }
     }
 
+    const fnHandleSuccessfulSubmit = (idPayload: {
+        formData: Record<string, unknown>
+        formId: string
+        formTitle?: string
+        meta?: Record<string, unknown>
+    }) => {
+        const LCaseStudyName = idPayload.meta?.case_study_name as string | undefined
+
+        identifyPostHogFormSubmitter(
+            idPayload.formData,
+            {
+                formId: idPayload.formId,
+                formTitle: idPayload.formTitle,
+                formSource: fnGetFormSource(idPayload.formId),
+                lastCaseStudyName: idPayload.formId === "download" ? LCaseStudyName : undefined,
+                newsletterOptIn: idPayload.formData.newsletter === true,
+            },
+        )
+    }
+
     const LdSectionRefs = (key: string): React.RefObject<HTMLDivElement> => {
         if (!RefStore.current[key]) {
             RefStore.current[key] = { current: null } as unknown as React.RefObject<HTMLDivElement>
@@ -190,18 +210,7 @@ export const useFormHandler = () => {
                         <SectionForm
                             config={LdFormConfig as TformConfig}
                             onSuccess={fnHandleFormSuccess}
-                            onSuccessfulSubmit={(idPayload) => {
-                                identifyPostHogFormSubmitter(
-                                    idPayload.formData,
-                                    {
-                                        formId: idPayload.formId,
-                                        formTitle: idPayload.formTitle,
-                                        formSource: fnGetFormSource(idPayload.formId),
-                                        lastCaseStudyName: idPayload.meta?.case_study_name as string | undefined,
-                                        newsletterOptIn: idPayload.formData.newsletter === true,
-                                    },
-                                )
-                            }}
+                            onSuccessfulSubmit={fnHandleSuccessfulSubmit}
                             onCancel={() => {
                                 fnSetActiveSection(null)
                             }}

--- a/app/hooks/form-handler.tsx
+++ b/app/hooks/form-handler.tsx
@@ -9,6 +9,7 @@ import { Button } from "@repo/ui/components/ui/button"
 import { SectionForm } from "@repo/ui/components/form"
 import { generateSchemaFromFields } from '@repo/ui/lib/zod-transformation'
 import { type TformMode, type TcaseStudies, type TtrendCardProps, type TformConfig } from "@repo/middleware/types"
+import { identifyPostHogFormSubmitter } from "../lib/posthog-identify"
 
 type OptionalRenderParams = {
     idData?: TtrendCardProps;
@@ -51,6 +52,21 @@ export const useFormHandler = () => {
     )
     const RefStore = useRef<Record<string, React.RefObject<HTMLDivElement>>>({})
     const FormRef = useRef<HTMLDivElement>(null)
+
+    const fnGetFormSource = (iFormId: string) => {
+        switch (iFormId) {
+            case "booking":
+                return "booking_form"
+            case "contact":
+                return "contact_form"
+            case "download":
+                return "case_study_download"
+            case "webinar":
+                return "webinar_form"
+            default:
+                return `${iFormId}_form`
+        }
+    }
 
     const LdSectionRefs = (key: string): React.RefObject<HTMLDivElement> => {
         if (!RefStore.current[key]) {
@@ -174,6 +190,18 @@ export const useFormHandler = () => {
                         <SectionForm
                             config={LdFormConfig as TformConfig}
                             onSuccess={fnHandleFormSuccess}
+                            onSuccessfulSubmit={(idPayload) => {
+                                identifyPostHogFormSubmitter(
+                                    idPayload.formData,
+                                    {
+                                        formId: idPayload.formId,
+                                        formTitle: idPayload.formTitle,
+                                        formSource: fnGetFormSource(idPayload.formId),
+                                        lastCaseStudyName: idPayload.meta?.case_study_name as string | undefined,
+                                        newsletterOptIn: idPayload.formData.newsletter === true,
+                                    },
+                                )
+                            }}
                             onCancel={() => {
                                 fnSetActiveSection(null)
                             }}

--- a/app/hooks/form-handler.tsx
+++ b/app/hooks/form-handler.tsx
@@ -86,6 +86,12 @@ export const useFormHandler = () => {
                 newsletterOptIn: idPayload.formData.newsletter === true,
             },
         )
+
+        if (idPayload.formId === "download") {
+            posthog.capture("case_study_download_requested", {
+                case_study_name: LCaseStudyName,
+            })
+        }
     }
 
     const LdSectionRefs = (key: string): React.RefObject<HTMLDivElement> => {

--- a/app/hooks/form-handler.tsx
+++ b/app/hooks/form-handler.tsx
@@ -75,11 +75,12 @@ export const useFormHandler = () => {
         meta?: Record<string, unknown>
     }) => {
         const LCaseStudyName = idPayload.meta?.case_study_name as string | undefined
+        const LIdentifyFormId = idPayload.formId === "download" ? "case_study" : idPayload.formId
 
         identifyPostHogFormSubmitter(
             idPayload.formData,
             {
-                formId: idPayload.formId,
+                formId: LIdentifyFormId,
                 formTitle: idPayload.formTitle,
                 formSource: fnGetFormSource(idPayload.formId),
                 lastCaseStudyName: idPayload.formId === "download" ? LCaseStudyName : undefined,

--- a/app/lib/posthog-identify.ts
+++ b/app/lib/posthog-identify.ts
@@ -36,7 +36,7 @@ export function identifyPostHogFormSubmitter(
 ) {
   const LEmail = fnNormalizeEmail(idFormData.email)
 
-  if (!LEmail || !posthog.__loaded) return
+  if (!LEmail) return
 
   const LSubmittedAt = new Date().toISOString()
   const LSetProperties: Record<string, unknown> = {
@@ -57,13 +57,17 @@ export function identifyPostHogFormSubmitter(
   if (LCaseStudyName) LSetProperties.last_case_study_name = LCaseStudyName
   if (idContext.newsletterOptIn) LSetProperties.newsletter_opt_in = true
 
+  const LSetOnceProperties: Record<string, unknown> = {
+    first_form_id: idContext.formId,
+    first_form_source: idContext.formSource,
+    first_submitted_at: LSubmittedAt,
+  }
+
+  if (LCaseStudyName) LSetOnceProperties.first_case_study_name = LCaseStudyName
+
   posthog.identify(
     LEmail,
     LSetProperties,
-    {
-      first_form_id: idContext.formId,
-      first_form_source: idContext.formSource,
-      first_submitted_at: LSubmittedAt,
-    },
+    LSetOnceProperties,
   )
 }

--- a/app/lib/posthog-identify.ts
+++ b/app/lib/posthog-identify.ts
@@ -1,0 +1,69 @@
+"use client"
+
+import posthog from "posthog-js"
+
+type TIdentifyContext = {
+  formId: string
+  formTitle?: string
+  formSource: string
+  lastCaseStudyName?: string
+  newsletterOptIn?: boolean
+}
+
+type TIdentifyFormData = {
+  email?: unknown
+  name?: unknown
+  phone?: unknown
+}
+
+const fnNormalizeEmail = (iEmail?: unknown) => {
+  if (typeof iEmail !== "string") return null
+
+  const LEmail = iEmail.trim().toLowerCase()
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(LEmail) ? LEmail : null
+}
+
+const fnStringProperty = (iValue?: unknown) => {
+  if (typeof iValue !== "string") return undefined
+
+  const LValue = iValue.trim()
+  return LValue || undefined
+}
+
+export function identifyPostHogFormSubmitter(
+  idFormData: TIdentifyFormData,
+  idContext: TIdentifyContext,
+) {
+  const LEmail = fnNormalizeEmail(idFormData.email)
+
+  if (!LEmail || !posthog.__loaded) return
+
+  const LSubmittedAt = new Date().toISOString()
+  const LSetProperties: Record<string, unknown> = {
+    email: LEmail,
+    last_form_id: idContext.formId,
+    last_form_source: idContext.formSource,
+    last_submitted_at: LSubmittedAt,
+  }
+
+  const LName = fnStringProperty(idFormData.name)
+  const LPhone = fnStringProperty(idFormData.phone)
+  const LFormTitle = fnStringProperty(idContext.formTitle)
+  const LCaseStudyName = fnStringProperty(idContext.lastCaseStudyName)
+
+  if (LName) LSetProperties.name = LName
+  if (LPhone) LSetProperties.phone = LPhone
+  if (LFormTitle) LSetProperties.last_form_title = LFormTitle
+  if (LCaseStudyName) LSetProperties.last_case_study_name = LCaseStudyName
+  if (idContext.newsletterOptIn) LSetProperties.newsletter_opt_in = true
+
+  posthog.identify(
+    LEmail,
+    LSetProperties,
+    {
+      first_form_id: idContext.formId,
+      first_form_source: idContext.formSource,
+      first_submitted_at: LSubmittedAt,
+    },
+  )
+}


### PR DESCRIPTION
## Summary
- Adds app-only PostHog identify helper using normalized lowercase email as `distinct_id`.
- Wires shared form submissions, direct contact/booking forms, case study downloads, and footer newsletter conversions into identify.
- Adds client newsletter listener while leaving existing PostHog init and `/ingest` proxy unchanged.

## Validation
- `pnpm --filter braccoli build` compiles successfully, then fails during page data collection because Strapi returns 401 for `https://dumps-240005.lmnaslens.com/graphql` while collecting `/[locale]/solutions/[slug]`. This appears to require valid CMS auth/env rather than a code compile fix.